### PR TITLE
Add analytics for production deployment

### DIFF
--- a/platform/viewer/public/html-templates/index.html
+++ b/platform/viewer/public/html-templates/index.html
@@ -2,6 +2,21 @@
 <html lang="en">
 
 <head>
+  
+<!-- Google Analytics -->
+<script>
+if (window.location.host == 'viewer.imaging.datacommons.cancer.gov') {
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+  ga('create', 'UA-151885665-6', 'auto');
+  ga('send', 'pageview');
+}
+</script>
+<!-- End Google Analytics -->
+  
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <meta name="theme-color" content="#000000" />


### PR DESCRIPTION
Conditionally add our google analytics code if we are hosted on the production site `viewer.imaging.datacommons.cancer.gov`

Fixes #6
