### PR TITLE
IDC ENH: 2 servers

### DIFF
--- a/idc-assets/app-config-template.js
+++ b/idc-assets/app-config-template.js
@@ -2,7 +2,7 @@ window.config = {
   // default: '/'
   routerBasename: '/',
   extensions: [],
-  disableMeasurementPanel: true,
+  disableMeasurementPanel: false,
   splitQueryParameterCalls: true,
   disableServersCache: true,
   showStudyList: false,
@@ -30,6 +30,26 @@ window.config = {
       },
     ],
   },
+  enableGoogleCloudAdapter: true,
+  healthcareApiEndpoint: 'https://healthcare.googleapis.com/v1',
+  oidc: [
+    {
+      // ~ REQUIRED
+      // Authorization Server URL
+      authority: 'https://accounts.google.com',
+      client_id:
+        'YOURCLIENTID.apps.googleusercontent.com',
+      redirect_uri: '/callback', // `OHIFStandaloneViewer.js`
+      response_type: 'id_token token',
+      scope:
+        'email profile openid https://www.googleapis.com/auth/cloudplatformprojects.readonly https://www.googleapis.com/auth/cloud-healthcare', // email profile openid
+      // ~ OPTIONAL
+      post_logout_redirect_uri: '/logout-redirect.html',
+      revoke_uri: 'https://accounts.google.com/o/oauth2/revoke?token=',
+      automaticSilentRenew: true,
+      revokeAccessTokenOnSignout: true,
+    },
+  ],
 
   // Extensions should be able to suggest default values for these?
   // Or we can require that these be explicitly set

--- a/idc-assets/public-config-template.js
+++ b/idc-assets/public-config-template.js
@@ -4,7 +4,7 @@ window.config = {
   enableGoogleCloudAdapter: true,
   studyListFunctionsEnabled: true,
   filterQueryParam: true,
-  disableMeasurementPanel: true,
+  disableMeasurementPanel: false,
   splitQueryParameterCalls: true,
   servers: {
     // This is an array, but we'll only use the first entry for now

--- a/platform/core/src/DICOMSR/dataExchange.js
+++ b/platform/core/src/DICOMSR/dataExchange.js
@@ -8,14 +8,6 @@ import {
 import findMostRecentStructuredReport from './utils/findMostRecentStructuredReport';
 
 /**
- *
- * @typedef serverType
- * @property {string} type - type of the server
- * @property {string} wadoRoot - server wado root url
- *
- */
-
-/**
  * Function to be registered into MeasurementAPI to retrieve measurements from DICOM Structured Reports
  *
  * @param {serverType} server
@@ -32,7 +24,6 @@ const retrieveMeasurements = (server, external = {}) => {
 
   const serverUrl = server.wadoRoot;
   const studies = utils.studyMetadataManager.all();
-
   const latestSeries = findMostRecentStructuredReport(studies);
 
   if (!latestSeries) return Promise.resolve({});

--- a/platform/core/src/DICOMSR/handleStructuredReport.js
+++ b/platform/core/src/DICOMSR/handleStructuredReport.js
@@ -35,11 +35,11 @@ const retrieveMeasurementFromSR = async (
 
   const dicomWeb = new api.DICOMwebClient(config);
 
-  const instance = series.getFirstInstance();
+  const instance = series.instances[0];
   const options = {
-    studyInstanceUID: instance.getStudyInstanceUID(),
-    seriesInstanceUID: instance.getSeriesInstanceUID(),
-    sopInstanceUID: instance.getSOPInstanceUID(),
+    studyInstanceUID: instance.metadata.StudyInstanceUID,
+    seriesInstanceUID: instance.metadata.SeriesInstanceUID,
+    sopInstanceUID: instance.metadata.SOPInstanceUID,
   };
 
   const part10SRArrayBuffer = await dicomWeb.retrieveInstance(options);

--- a/platform/core/src/DICOMSR/utils/findMostRecentStructuredReport.js
+++ b/platform/core/src/DICOMSR/utils/findMostRecentStructuredReport.js
@@ -8,12 +8,13 @@ const findMostRecentStructuredReport = studies => {
   let mostRecentStructuredReport;
 
   studies.forEach(study => {
-    const allSeries = study.getSeries ? study.getSeries() : [];
+    const allData = study.getData ? study.getData() : [];
+    const allSeries = allData.series;
     allSeries.forEach(series => {
       // Skip series that may not have instances yet
       // This can happen if we have retrieved just the initial
       // details about the series via QIDO-RS, but not the full metadata
-      if (!series || series.getInstanceCount() === 0) {
+      if (!series || !series.instances || series.instances.length === 0) {
         return;
       }
 
@@ -44,8 +45,8 @@ const isStructuredReportSeries = series => {
     '1.2.840.10008.5.1.4.1.1.88.34', // COMPREHENSIVE_3D_SR
   ];
 
-  const firstInstance = series.getFirstInstance();
-  const SOPClassUID = firstInstance.getData().metadata.SOPClassUID;
+  const firstInstance = series.instances[0];
+  const SOPClassUID = firstInstance.metadata.SOPClassUID;
 
   return supportedSopClassUIDs.includes(SOPClassUID);
 };
@@ -59,9 +60,9 @@ const isStructuredReportSeries = series => {
  */
 const compareSeriesDate = (series1, series2) => {
   return (
-    series1._data.SeriesDate > series2._data.SeriesDate ||
-    (series1._data.SeriesDate === series2._data.SeriesDate &&
-      series1._data.SeriesTime > series2._data.SeriesTime)
+    series1.SeriesDate > series2.SeriesDate ||
+    (series1.SeriesDate === series2.SeriesDate &&
+      series1.SeriesTime > series2.SeriesTime)
   );
 };
 

--- a/platform/core/src/studies/retrieveStudiesMetadata.js
+++ b/platform/core/src/studies/retrieveStudiesMetadata.js
@@ -7,7 +7,7 @@ import { retrieveStudyMetadata } from './retrieveStudyMetadata';
  * This function calls retrieveStudyMetadata several times, asynchronously,
  * and waits for all of the results to be returned.
  *
- * @param {Object} server Object with server configuration parameters
+ * @param {Array} servers array with server Objects with server configuration parameters
  * @param {Array} studyInstanceUIDs The UIDs of the Studies to be retrieved
  * @param {Object} [filters] - Object containing filters to be applied on retrieve metadata process
  * @param {string} [filter.seriesInstanceUID] - series instance uid to filter results against
@@ -16,7 +16,7 @@ import { retrieveStudyMetadata } from './retrieveStudyMetadata';
  * @returns {Promise} that will be resolved with the metadata or rejected with the error
  */
 export default function retrieveStudiesMetadata(
-  server,
+  servers,
   studyInstanceUIDs,
   filters,
   separateSeriesInstanceUIDFilters = false
@@ -28,7 +28,7 @@ export default function retrieveStudiesMetadata(
   studyInstanceUIDs.forEach(function(StudyInstanceUID) {
     // Send the call and resolve or reject the related promise based on its outcome
     const promise = retrieveStudyMetadata(
-      server,
+      servers,
       StudyInstanceUID,
       filters,
       separateSeriesInstanceUIDFilters

--- a/platform/core/src/studies/retrieveStudyMetadata.js
+++ b/platform/core/src/studies/retrieveStudyMetadata.js
@@ -7,7 +7,7 @@ const StudyMetaDataPromises = new Map();
 /**
  * Retrieves study metadata
  *
- * @param {Object} server Object with server configuration parameters
+ * @param {Array} servers array with server Objects with server configuration parameters
  * @param {string} StudyInstanceUID The UID of the Study to be retrieved
  * @param {Object} [filters] - Object containing filters to be applied on retrieve metadata process
  * @param {string} [filter.seriesInstanceUID] - series instance uid to filter results against
@@ -16,7 +16,7 @@ const StudyMetaDataPromises = new Map();
  * @returns {Promise} that will be resolved with the metadata or rejected with the error
  */
 export function retrieveStudyMetadata(
-  server,
+  servers,
   StudyInstanceUID,
   filters,
   separateSeriesInstanceUIDFilters = false
@@ -25,8 +25,10 @@ export function retrieveStudyMetadata(
   // and further requests for that metadata will always fail. On failure, we probably need to remove the
   // corresponding promise from the "StudyMetaDataPromises" map...
 
-  if (!server) {
-    throw new Error(`${moduleName}: Required 'server' parameter not provided.`);
+  if (!servers) {
+    throw new Error(
+      `${moduleName}: Required 'servers' parameter not provided.`
+    );
   }
   if (!StudyInstanceUID) {
     throw new Error(
@@ -48,20 +50,12 @@ export function retrieveStudyMetadata(
     separateSeriesInstanceUIDFilters
   ) {
     promise = __separateSeriesRequestToAggregatePromiseateSeriesRequestToAggregatePromise(
-      server,
+      servers,
       StudyInstanceUID,
       filters
     );
   } else {
-    promise = RetrieveMetadata(server, StudyInstanceUID, filters);
-
-    /*
-    promise = new Promise((resolve, reject) => {
-      RetrieveMetadata(server, StudyInstanceUID, filters).then(function(data) {
-        resolve(data);
-      }, reject);
-    });
-    */
+    promise = RetrieveMetadata(servers, StudyInstanceUID, filters);
   }
 
   // Store the promise in cache
@@ -72,12 +66,12 @@ export function retrieveStudyMetadata(
 
 /**
  * Splits up seriesInstanceUID filters to multiple calls for platforms
- * @param {Object} server Object with server configuration parameters
+ * @param {Array} servers array with server Objects with server configuration parameters
  * @param {string} StudyInstanceUID The UID of the Study to be retrieved
  * @param {Object} filters - Object containing filters to be applied on retrieve metadata process
  */
 function __separateSeriesRequestToAggregatePromiseateSeriesRequestToAggregatePromise(
-  server,
+  servers,
   StudyInstanceUID,
   filters
 ) {
@@ -93,7 +87,7 @@ function __separateSeriesRequestToAggregatePromiseateSeriesRequestToAggregatePro
       });
 
       promises.push(
-        RetrieveMetadata(server, StudyInstanceUID, seriesSpecificFilters)
+        RetrieveMetadata(servers, StudyInstanceUID, seriesSpecificFilters)
       );
     });
 

--- a/platform/core/src/studies/services/wado/retrieveMetadata.js
+++ b/platform/core/src/studies/services/wado/retrieveMetadata.js
@@ -5,26 +5,33 @@ import RetrieveMetadataLoaderAsync from './retrieveMetadataLoaderAsync';
  * Retrieve Study metadata from a DICOM server. If the server is configured to use lazy load, only the first series
  * will be loaded and the property "studyLoader" will be set to let consumer load remaining series as needed.
  *
- * @param {Object} server Object with server configuration parameters
+ * @param {Array} servers array with server Objects with server configuration parameters
  * @param {string} StudyInstanceUID The Study Instance UID of the study which needs to be loaded
  * @param {Object} [filters] - Object containing filters to be applied on retrieve metadata process
  * @param {string} [filter.seriesInstanceUID] - series instance uid to filter results against
- * @returns {Object} A study descriptor object
+ * @returns {Array} A study descriptor object for each server
  */
-async function RetrieveMetadata(server, StudyInstanceUID, filters = {}) {
-  const RetrieveMetadataLoader =
-    server.enableStudyLazyLoad != false
-      ? RetrieveMetadataLoaderAsync
-      : RetrieveMetadataLoaderSync;
+async function RetrieveMetadata(servers, StudyInstanceUID, filters = {}) {
+  return new Promise((resolve, reject) => {
+    const studyMetadataPromises = servers.map(server => {
+      const RetrieveMetadataLoader =
+        server.enableStudyLazyLoad != false
+          ? RetrieveMetadataLoaderAsync
+          : RetrieveMetadataLoaderSync;
 
-  const retrieveMetadataLoader = new RetrieveMetadataLoader(
-    server,
-    StudyInstanceUID,
-    filters
-  );
-  const studyMetadata = retrieveMetadataLoader.execLoad();
+      const retrieveMetadataLoader = new RetrieveMetadataLoader(
+        server,
+        StudyInstanceUID,
+        filters
+      );
+      const studyMetadataPromise = retrieveMetadataLoader.execLoad();
+      return studyMetadataPromise;
+    });
 
-  return studyMetadata;
+    Promise.all(studyMetadataPromises).then(results => {
+      resolve(results);
+    }, reject);
+  });
 }
 
 export default RetrieveMetadata;

--- a/platform/viewer/src/OHIFStandaloneViewer.js
+++ b/platform/viewer/src/OHIFStandaloneViewer.js
@@ -5,7 +5,12 @@ import { Route, Switch } from 'react-router-dom';
 import { NProgress } from '@tanem/react-nprogress';
 import { CSSTransition } from 'react-transition-group';
 import { connect } from 'react-redux';
-import { ViewerbaseDragDropContext, ErrorBoundary, asyncComponent, retryImport } from '@ohif/ui';
+import {
+  ViewerbaseDragDropContext,
+  ErrorBoundary,
+  asyncComponent,
+  retryImport,
+} from '@ohif/ui';
 import { SignoutCallbackComponent } from 'redux-oidc';
 import * as RoutesUtil from './routes/routesUtil';
 
@@ -17,7 +22,9 @@ import './theme-tide.css';
 // Contexts
 import AppContext from './context/AppContext';
 const CallbackPage = asyncComponent(() =>
-  retryImport(() => import(/* webpackChunkName: "CallbackPage" */ './routes/CallbackPage.js'))
+  retryImport(() =>
+    import(/* webpackChunkName: "CallbackPage" */ './routes/CallbackPage.js')
+  )
 );
 
 class OHIFStandaloneViewer extends Component {
@@ -202,10 +209,10 @@ class OHIFStandaloneViewer extends Component {
                   {match === null ? (
                     <></>
                   ) : (
-                      <ErrorBoundary context={match.url}>
-                        <Component match={match} location={this.props.location} />
-                      </ErrorBoundary>
-                    )}
+                    <ErrorBoundary context={match.url}>
+                      <Component match={match} location={this.props.location} />
+                    </ErrorBoundary>
+                  )}
                 </CSSTransition>
               )}
             </Route>

--- a/platform/viewer/src/connectedComponents/ConnectedViewer.js
+++ b/platform/viewer/src/connectedComponents/ConnectedViewer.js
@@ -6,7 +6,20 @@ const { setTimepoints, setMeasurements } = OHIF.redux.actions;
 
 const getActiveServer = servers => {
   const isActive = a => a.active === true;
-  return servers.servers.find(isActive);
+  const isGoogleStore = a => a.isGoogleStore === true;
+
+  let activeServers = 0;
+  servers.servers.forEach(server => {
+    if (server.active === true) {
+      activeServers = activeServers + 1;
+    }
+  });
+
+  if (activeServers > 1) {
+    return servers.servers.find(isActive && isGoogleStore);
+  } else {
+    return servers.servers.find(isActive);
+  }
 };
 
 const mapStateToProps = state => {

--- a/platform/viewer/src/connectedComponents/ConnectedViewerRetrieveStudyData.js
+++ b/platform/viewer/src/connectedComponents/ConnectedViewerRetrieveStudyData.js
@@ -3,13 +3,10 @@ import ViewerRetrieveStudyData from './ViewerRetrieveStudyData.js';
 import OHIF from '@ohif/core';
 
 const { clearViewportSpecificData, setStudyData } = OHIF.redux.actions;
-const isActive = a => a.active === true;
 
-const mapStateToProps = (state, ownProps) => {
-  const activeServer = state.servers.servers.find(isActive);
-
+const mapStateToProps = state => {
   return {
-    server: ownProps.server || activeServer,
+    servers: state.servers.servers,
   };
 };
 const mapDispatchToProps = dispatch => {

--- a/platform/viewer/src/connectedComponents/Viewer.js
+++ b/platform/viewer/src/connectedComponents/Viewer.js
@@ -67,19 +67,6 @@ class Viewer extends Component {
   constructor(props) {
     super(props);
 
-    const { activeServer } = this.props;
-    const server = Object.assign({}, activeServer);
-
-    const external = { servicesManager };
-
-    OHIF.measurements.MeasurementApi.setConfiguration({
-      dataExchange: {
-        retrieve: server => DICOMSR.retrieveMeasurements(server, external),
-        store: DICOMSR.storeMeasurements,
-      },
-      server,
-    });
-
     OHIF.measurements.TimepointApi.setConfiguration({
       dataExchange: {
         retrieve: this.retrieveTimepoints,
@@ -197,8 +184,8 @@ class Viewer extends Component {
     if (studies) {
       const PatientID = studies[0] && studies[0].PatientID;
 
-      timepointApi.retrieveTimepoints({ PatientID });
       if (isStudyLoaded) {
+        timepointApi.retrieveTimepoints({ PatientID });
         this.measurementApi.retrieveMeasurements(PatientID, [
           currentTimepointId,
         ]);
@@ -231,8 +218,8 @@ class Viewer extends Component {
       isStudyLoaded,
       activeViewportIndex,
       viewports,
+      activeServer,
     } = this.props;
-
     const activeViewport = viewports[activeViewportIndex];
     const activeDisplaySetInstanceUID = activeViewport
       ? activeViewport.displaySetInstanceUID
@@ -257,7 +244,19 @@ class Viewer extends Component {
         activeDisplaySetInstanceUID,
       });
     }
-    if (isStudyLoaded && isStudyLoaded !== prevProps.isStudyLoaded) {
+    if (prevProps.studies !== studies && studies.length !== 0) {
+      const server = Object.assign({}, activeServer);
+      console.info('bella4', server, studies);
+      const external = { servicesManager };
+
+      OHIF.measurements.MeasurementApi.setConfiguration({
+        dataExchange: {
+          retrieve: server => DICOMSR.retrieveMeasurements(server, external),
+          store: DICOMSR.storeMeasurements,
+        },
+        server,
+      });
+
       const PatientID = studies[0] && studies[0].PatientID;
       const { currentTimepointId } = this;
 

--- a/platform/viewer/src/connectedComponents/ViewerMain.js
+++ b/platform/viewer/src/connectedComponents/ViewerMain.js
@@ -50,9 +50,11 @@ class ViewerMain extends Component {
       return;
     }
 
-    return study.displaySets.find(displaySet => {
+    const displaySet = study.displaySets.find(displaySet => {
       return displaySet.displaySetInstanceUID === displaySetInstanceUID;
     });
+
+    return displaySet;
   }
 
   componentDidMount() {
@@ -138,6 +140,10 @@ class ViewerMain extends Component {
       StudyInstanceUID,
       displaySetInstanceUID
     );
+
+    if (!displaySet) {
+      return;
+    }
 
     const { LoggerService, UINotificationService } = servicesManager.services;
 

--- a/platform/viewer/src/connectedComponents/ViewerRetrieveStudyData.js
+++ b/platform/viewer/src/connectedComponents/ViewerRetrieveStudyData.js
@@ -12,8 +12,8 @@ import AppContext from '../context/AppContext';
 import NotFound from '../routes/NotFound';
 
 const { OHIFStudyMetadata, OHIFSeriesMetadata } = metadata;
-const { retrieveStudiesMetadata, deleteStudyMetadataPromise } = studies;
-const { studyMetadataManager, makeCancelable } = utils;
+const { retrieveStudiesMetadata } = studies;
+const { studyMetadataManager } = utils;
 
 const _promoteToFront = (list, values, searchMethod) => {
   let listCopy = [...list];
@@ -171,8 +171,6 @@ const _addSeriesToStudy = (studyMetadata, series) => {
   study.derivedDisplaySets = studyMetadata.getDerivedDatasets({
     Modality: series.Modality,
   });
-
-  _updateStudyMetadataManager(study, studyMetadata);
 };
 
 const _updateStudyMetadataManager = (study, studyMetadata) => {
@@ -180,15 +178,6 @@ const _updateStudyMetadataManager = (study, studyMetadata) => {
 
   if (!studyMetadataManager.get(StudyInstanceUID)) {
     studyMetadataManager.add(studyMetadata);
-  }
-};
-
-const _updateStudyDisplaySets = (study, studyMetadata) => {
-  const sopClassHandlerModules =
-    extensionManager.modules['sopClassHandlerModule'];
-
-  if (!study.displaySets) {
-    study.displaySets = studyMetadata.createDisplaySets(sopClassHandlerModules);
   }
 
   if (study.derivedDisplaySets) {
@@ -206,7 +195,7 @@ const _thinStudyData = study => {
 };
 
 function ViewerRetrieveStudyData({
-  server,
+  servers,
   studyInstanceUIDs,
   seriesInstanceUIDs,
   clearViewportSpecificData,
@@ -223,8 +212,6 @@ function ViewerRetrieveStudyData({
     maxConcurrentMetadataRequests,
   } = appConfig;
 
-  let cancelableSeriesPromises;
-  let cancelableStudiesPromises;
   /**
    * Callback method when study is totally loaded
    * @param {object} study study loaded
@@ -257,52 +244,154 @@ function ViewerRetrieveStudyData({
       'Query parameters were not totally applied. It might be using original series list for given study.',
       snackbarContext
     );
-
-    setStudies([...studies, study]);
   };
 
   /**
    * Method to process studies. It will update displaySet, studyMetadata, load remaining series, ...
-   * @param {Array} studiesData Array of studies retrieved from server
+   * @param {Array} studiesData Array of studies retrieved from server, each study is an array (each element is a server)
    * @param {Object} [filters] - Object containing filters to be applied
    * @param {string} [filters.seriesInstanceUID] - series instance uid to filter results against
    */
-  const processStudies = (studiesData, filters) => {
+  const processStudies = async (studiesData, filters) => {
+    studiesData = [].concat(...studiesData);
     if (Array.isArray(studiesData) && studiesData.length > 0) {
       // Map studies to new format, update metadata manager?
-      const studies = studiesData.map(study => {
-        setStudyData(study.StudyInstanceUID, _thinStudyData(study));
+      const studiesLoading = await Promise.all(
+        await studiesData.map(async study => {
+          const studyMetadata = new OHIFStudyMetadata(
+            study,
+            study.StudyInstanceUID
+          );
+
+          // Attempt to load remaning series if any
+          try {
+            await loadRemainingSeries(studyMetadata);
+          } catch (error) {
+            if (error) {
+              setError(error);
+              log.error(error);
+            }
+          }
+
+          return study;
+        })
+      );
+
+      // for one StudyUID we could have N study object at this point (for N server).
+      // we merge them in 1 unique study, since OHIF-v2 assume only one object for each StudyUID.
+      // duplicate series will be removed.
+      let mergedStudies = [];
+      for (let i = 0; i < studiesLoading.length; i++) {
+        const study = studiesLoading[i];
         const studyMetadata = new OHIFStudyMetadata(
           study,
           study.StudyInstanceUID
         );
 
-        _updateStudyDisplaySets(study, studyMetadata);
+        _addSeriesToStudy(studyMetadata, study.series[0]);
+
+        if (mergedStudies.length !== 0) {
+          const found = mergedStudies.find(
+            mergedStudy =>
+              mergedStudy.StudyInstanceUID === study.StudyInstanceUID
+          );
+
+          if (found !== -1) {
+            continue;
+          }
+        }
+
+        for (let j = 0; j < studiesLoading.length; j++) {
+          if (i === j) {
+            continue;
+          }
+
+          const comparedStudy = studiesLoading[j];
+          if (study.StudyInstanceUID !== comparedStudy.StudyInstanceUID) {
+            continue;
+          }
+
+          if (comparedStudy.series && comparedStudy.series.length !== 0) {
+            comparedStudy.series.forEach(series => {
+              if (study.series.length !== 0) {
+                const found = study.series.find(
+                  studySeries =>
+                    studySeries.SeriesInstanceUID === series.SeriesInstanceUID
+                );
+                if (found) {
+                  return;
+                }
+              }
+
+              study.series.push(series);
+              _addSeriesToStudy(studyMetadata, series);
+            });
+          }
+
+          if (
+            comparedStudy.derivedDisplaySets &&
+            comparedStudy.derivedDisplaySets.length !== 0
+          ) {
+            comparedStudy.derivedDisplaySets.forEach(derivedDisplaySet => {
+              if (study.derivedDisplaySets.length !== 0) {
+                const found = study.derivedDisplaySets.find(
+                  studyDerivedDisplaySet =>
+                    studyDerivedDisplaySet.SeriesInstanceUID ===
+                    derivedDisplaySet.SeriesInstanceUID
+                );
+                if (found) {
+                  return;
+                }
+              }
+
+              study.derivedDisplaySets.push(derivedDisplaySet);
+            });
+          }
+
+          if (
+            comparedStudy.displaySets &&
+            comparedStudy.displaySets.length !== 0
+          ) {
+            comparedStudy.displaySets.forEach(displaySet => {
+              if (study.displaySets.length !== 0) {
+                const found = study.displaySets.find(
+                  studyDisplaySet =>
+                    studyDisplaySet.SeriesInstanceUID ===
+                    displaySet.SeriesInstanceUID
+                );
+                if (found) {
+                  return;
+                }
+              }
+
+              study.displaySets.push(displaySet);
+            });
+          }
+
+          if (comparedStudy.seriesMap) {
+            for (let key in comparedStudy.seriesMap) {
+              for (let prop in study.seriesMap) {
+                if (prop === key) {
+                  continue;
+                }
+              }
+
+              study.seriesMap[key] = comparedStudy.seriesMap[key];
+            }
+          }
+        }
+
+        study.displaySets.forEach(displaySet => {
+          studyMetadata.addDisplaySet(displaySet);
+        });
+
         _updateStudyMetadataManager(study, studyMetadata);
+        setStudyData(study.StudyInstanceUID, _thinStudyData(study));
+        studyDidLoad(study, studyMetadata, filters);
+        mergedStudies.push(study);
+      }
 
-        // Attempt to load remaning series if any
-        cancelableSeriesPromises[study.StudyInstanceUID] = makeCancelable(
-          loadRemainingSeries(studyMetadata)
-        )
-          .then(result => {
-            if (result && !result.isCanceled) {
-              studyDidLoad(study, studyMetadata, filters);
-            }
-          })
-          .catch(error => {
-            if (error && !error.isCanceled) {
-              setError(error);
-              log.error(error);
-            }
-          })
-          .finally(() => {
-            setIsStudyLoaded(true);
-          });
-
-        return study;
-      });
-
-      setStudies(studies);
+      setStudies(mergedStudies);
     }
   };
 
@@ -330,12 +419,12 @@ function ViewerRetrieveStudyData({
     return remainingPromises;
   };
 
-  const loadStudies = async () => {
+  const loadStudies = useCallback(async () => {
     try {
       const filters = {};
       // Use the first, discard others
       const seriesInstanceUID = seriesInstanceUIDs && seriesInstanceUIDs[0];
-      const retrieveParams = [server, studyInstanceUIDs];
+      const retrieveParams = [servers, studyInstanceUIDs];
 
       if (seriesInstanceUID) {
         filters.seriesInstanceUID = seriesInstanceUID;
@@ -352,40 +441,20 @@ function ViewerRetrieveStudyData({
         retrieveParams.push(true); // Seperate SeriesInstanceUID filter calls.
       }
 
-      cancelableStudiesPromises[studyInstanceUIDs] = makeCancelable(
-        retrieveStudiesMetadata(...retrieveParams)
-      )
-        .then(result => {
-          if (result && !result.isCanceled) {
-            processStudies(result, filters);
-          }
-        })
-        .catch(error => {
-          if (error && !error.isCanceled) {
-            setError(error);
-            log.error(error);
-          }
-        });
+      try {
+        const result = await retrieveStudiesMetadata(...retrieveParams);
+        await processStudies(result, filters);
+        setIsStudyLoaded(true);
+      } catch (error) {
+        if (error) {
+          setError(error);
+          log.error(error);
+        }
+      }
     } catch (error) {
       if (error) {
         setError(error);
         log.error(error);
-      }
-    }
-  };
-
-  const purgeCancellablePromises = useCallback(() => {
-    for (let studyInstanceUIDs in cancelableStudiesPromises) {
-      if ('cancel' in cancelableStudiesPromises[studyInstanceUIDs]) {
-        cancelableStudiesPromises[studyInstanceUIDs].cancel();
-      }
-    }
-
-    for (let studyInstanceUIDs in cancelableSeriesPromises) {
-      if ('cancel' in cancelableSeriesPromises[studyInstanceUIDs]) {
-        cancelableSeriesPromises[studyInstanceUIDs].cancel();
-        deleteStudyMetadataPromise(studyInstanceUIDs);
-        studyMetadataManager.remove(studyInstanceUIDs);
       }
     }
   });
@@ -400,18 +469,13 @@ function ViewerRetrieveStudyData({
 
     if (hasStudyInstanceUIDsChanged) {
       studyMetadataManager.purge();
-      purgeCancellablePromises();
     }
-  }, [prevStudyInstanceUIDs, purgeCancellablePromises, studyInstanceUIDs]);
+  }, [prevStudyInstanceUIDs, studyInstanceUIDs]);
 
   useEffect(() => {
-    cancelableSeriesPromises = {};
-    cancelableStudiesPromises = {};
     loadStudies();
 
-    return () => {
-      purgeCancellablePromises();
-    };
+    return () => {};
   }, []);
 
   if (error) {
@@ -435,7 +499,7 @@ function ViewerRetrieveStudyData({
 ViewerRetrieveStudyData.propTypes = {
   studyInstanceUIDs: PropTypes.array.isRequired,
   seriesInstanceUIDs: PropTypes.array,
-  server: PropTypes.object,
+  servers: PropTypes.object,
   clearViewportSpecificData: PropTypes.func.isRequired,
   setStudyData: PropTypes.func.isRequired,
 };

--- a/platform/viewer/src/customHooks/useServer.js
+++ b/platform/viewer/src/customHooks/useServer.js
@@ -4,7 +4,6 @@ import usePrevious from './usePrevious';
 
 import * as GoogleCloudUtilServers from '../googleCloud/utils/getServers';
 import { useSelector, useDispatch } from 'react-redux';
-import isEqual from 'lodash.isequal';
 
 // Contexts
 import AppContext from '../context/AppContext';
@@ -64,11 +63,7 @@ const useServerFromUrl = (
   previousServers,
   activeServer,
   urlBasedServers,
-  appConfig,
-  project,
-  location,
-  dataset,
-  dicomStore
+  appConfig
 ) => {
   // update state from url available only when gcloud on
   if (!appConfig.enableGoogleCloudAdapter) {
@@ -109,7 +104,6 @@ export default function useServer({
   const servers = useSelector(state => state && state.servers);
   const previousServers = usePrevious(servers);
   const dispatch = useDispatch();
-
   const { appConfig = {} } = useContext(AppContext);
 
   const activeServer = getActiveServer(servers);
@@ -128,8 +122,14 @@ export default function useServer({
   );
 
   if (shouldUpdateServer) {
-    setServers(dispatch, urlBasedServers);
+    const mergedServers = [...servers.servers, ...urlBasedServers];
+    setServers(dispatch, mergedServers);
+    return mergedServers[0];
   } else if (isValidServer(activeServer, appConfig)) {
     return activeServer;
+  }
+
+  if (servers.servers && servers.servers.length > 0) {
+    return servers.servers[0];
   }
 }

--- a/platform/viewer/src/googleCloud/utils/getServers.js
+++ b/platform/viewer/src/googleCloud/utils/getServers.js
@@ -20,6 +20,7 @@ const getServers = (data, name) => {
       thumbnailRendering: 'wadors',
       type: 'dicomWeb',
       active: true,
+      isGoogleStore: true,
       wadoUriRoot,
       qidoRoot,
       wadoRoot,

--- a/platform/viewer/src/routes/routesUtil.js
+++ b/platform/viewer/src/routes/routesUtil.js
@@ -6,27 +6,37 @@ const { urlUtil: UrlUtil } = OHIF.utils;
 // Dynamic Import Routes (CodeSplitting)
 const IHEInvokeImageDisplay = asyncComponent(() =>
   retryImport(() =>
-    import(/* webpackChunkName: "IHEInvokeImageDisplay" */ './IHEInvokeImageDisplay.js')
+    import(
+      /* webpackChunkName: "IHEInvokeImageDisplay" */ './IHEInvokeImageDisplay.js'
+    )
   )
 );
 const ViewerRouting = asyncComponent(() =>
-  retryImport(() => import(/* webpackChunkName: "ViewerRouting" */ './ViewerRouting.js'))
+  retryImport(() =>
+    import(/* webpackChunkName: "ViewerRouting" */ './ViewerRouting.js')
+  )
 );
 
 const StudyListRouting = asyncComponent(() =>
-  retryImport(() => import(
-    /* webpackChunkName: "StudyListRouting" */ '../studylist/StudyListRouting.js'
-  ))
+  retryImport(() =>
+    import(
+      /* webpackChunkName: "StudyListRouting" */ '../studylist/StudyListRouting.js'
+    )
+  )
 );
 const StandaloneRouting = asyncComponent(() =>
-  retryImport(() => import(
-    /* webpackChunkName: "ConnectedStandaloneRouting" */ '../connectedComponents/ConnectedStandaloneRouting.js'
-  ))
+  retryImport(() =>
+    import(
+      /* webpackChunkName: "ConnectedStandaloneRouting" */ '../connectedComponents/ConnectedStandaloneRouting.js'
+    )
+  )
 );
 const ViewerLocalFileData = asyncComponent(() =>
-  retryImport(() => import(
-    /* webpackChunkName: "ViewerLocalFileData" */ '../connectedComponents/ViewerLocalFileData.js'
-  ))
+  retryImport(() =>
+    import(
+      /* webpackChunkName: "ViewerLocalFileData" */ '../connectedComponents/ViewerLocalFileData.js'
+    )
+  )
 );
 
 const reload = () => window.location.reload();
@@ -54,7 +64,7 @@ const ROUTES_DEF = {
     },
     IHEInvokeImageDisplay: {
       path: '/IHEInvokeImageDisplay',
-      component: IHEInvokeImageDisplay
+      component: IHEInvokeImageDisplay,
     },
   },
   gcloud: {
@@ -74,6 +84,16 @@ const ROUTES_DEF = {
         const showList = appConfig.showStudyList;
 
         return showList && !!appConfig.enableGoogleCloudAdapter;
+      },
+    },
+  },
+  defaultAndgcloud: {
+    viewer: {
+      path:
+        '/viewer/:studyInstanceUIDs!secondGoogleServer=/projects/:project/locations/:location/datasets/:dataset/dicomStores/:dicomStore/study/:studyInstanceUIDs',
+      component: ViewerRouting,
+      condition: appConfig => {
+        return !!appConfig.enableGoogleCloudAdapter;
       },
     },
   },


### PR DESCRIPTION
@pieper @fedorov  This is a first attempt to implement fetching from multiple servers.

The user case is 2 servers only in reading. The first with the source data, the second with annotation. Specifically the first is supposed to be a publlic server (e.g. dev-proxy.canceridc.dev), the second a google store.

This has been tested over this datasets https://viewer.imaging.datacommons.cancer.gov/viewer/1.3.6.1.4.1.14519.5.2.1.6655.2359.247426265538388028079845922798  (only source data)

against the dataset in this google store  /projects/idc-tcia/locations/us-central1/datasets/tcia-idc-datareviewcoordination/dicomStores/planar_annotations/study/1.3.6.1.4.1.14519.5.2.1.6655.2359.247426265538388028079845922798  (source data + annotation)

Currently the logic is to fetch the data from both servers, merge the results (for series found twice, it ignores the ones coming from the second server).

the first server is specified in the config file and the config parameters for enabling the GoogleCloudAdapter as well. i.e.:

https://github.com/Punzo/Viewers/blob/IDC2servers/platform/viewer/public/config/default.js#L18-L51

Once this is setup, one can open the study from two servers as:

http://localhost:3000/viewer/1.3.6.1.4.1.14519.5.2.1.6655.2359.247426265538388028079845922798!secondGoogleServer=/projects/idc-tcia/locations/us-central1/datasets/tcia-idc-datareviewcoordination/dicomStores/planar_annotations/study/1.3.6.1.4.1.14519.5.2.1.6655.2359.247426265538388028079845922798 

Here a video:

https://user-images.githubusercontent.com/7985338/168128499-349a047d-0011-4a04-a0b4-1748a10784a0.mp4



Two issues:
1) Since we need to fetch all the metadata from the two servers and then operating filtering (e.g. removing double series), we can not start updating the UI until all the metadata have been fetched (i.e. this results in a small delay of the UI in showing the thumbnails)
2) We need to set the config parameters for enabling the GoogleCloudAdapter in the configuration file. This means taht if we try to load only from the first server (i.e. like, http://localhost:3000/viewer/1.3.6.1.4.1.14519.5.2.1.6655.2359.247426265538388028079845922798), still the user will be asked to log in google.

Before merging I would test this in the @pieper sandbox. Steve please let me know if you can deploy thiis branch https://github.com/ImagingDataCommons/Viewers/tree/IDC2servers against testing-viewer.canceridc.dev + googleAdapter