### PR TITLE
remove redundant code to update studydatamanager

### DIFF
--- a/platform/viewer/src/connectedComponents/ViewerRetrieveStudyData.js
+++ b/platform/viewer/src/connectedComponents/ViewerRetrieveStudyData.js
@@ -179,10 +179,6 @@ const _updateStudyMetadataManager = (study, studyMetadata) => {
   if (!studyMetadataManager.get(StudyInstanceUID)) {
     studyMetadataManager.add(studyMetadata);
   }
-
-  if (study.derivedDisplaySets) {
-    studyMetadata._addDerivedDisplaySets(study.derivedDisplaySets);
-  }
 };
 
 const _thinStudyData = study => {


### PR DESCRIPTION
Fixes https://github.com/OHIF/Viewers/issues/3098.
The issue was due to a redundant update to studydatamanager at https://github.com/ImagingDataCommons/Viewers/blob/9344beeafb7c113b4fcd3bcef6cba50a75beefcb/platform/viewer/src/connectedComponents/ViewerRetrieveStudyData.js#L390 after https://github.com/ImagingDataCommons/Viewers/blob/9344beeafb7c113b4fcd3bcef6cba50a75beefcb/platform/viewer/src/connectedComponents/ViewerRetrieveStudyData.js#L291

![OHIF Viewer - Google Chrome 2023-01-11 2_35_33](https://user-images.githubusercontent.com/112136540/211936045-e69d9da0-0277-4693-a7ee-5e6f82e21337.png)


https://user-images.githubusercontent.com/112136540/211936099-4437b445-eb0f-4c4d-9735-f06faacaf7f1.mp4

