### PR TITLE
Address const error when loading rt data

### DIFF
--- a/extensions/dicom-rt/src/loadRTStruct.js
+++ b/extensions/dicom-rt/src/loadRTStruct.js
@@ -75,7 +75,7 @@ export default async function loadRTStruct(
       continue;
     }
 
-    const isSupported = false;
+    let isSupported = false;
 
     const ContourSequenceArray = _toArray(ContourSequence);
 


### PR DESCRIPTION
- Load study: https://testing-viewer.canceridc.dev/viewer/1.3.6.1.4.1.14519.5.2.1.331091750152242639961456284359619743638
- Load RT series
- Error is thrown: ```OHIFDicomRTStructSopClassHandler.js:86 Uncaught (in promise) Error: TypeError: Assignment to constant variable.
    at OHIFDicomRTStructSopClassHandler.js:86:15```