### PR TITLE
fix exception in OHIF patient name format

### DIFF
--- a/platform/core/src/utils/formatPN.js
+++ b/platform/core/src/utils/formatPN.js
@@ -6,7 +6,13 @@ export default function formatPN(name) {
     return;
   }
 
-  const nameToUse = name.Alphabetic ?? name;
+  let nameToUse;
+  const _nameToUse = name.Alphabetic ?? name;
+  if (typeof _nameToUse === 'string' || _nameToUse instanceof String) {
+    nameToUse = _nameToUse;
+  } else {
+    nameToUse = '';
+  }
 
   // Convert the first ^ to a ', '. String.replace() only affects
   // the first appearance of the character.


### PR DESCRIPTION
The format patient name function causes an error in IDC servers related to a name not defined properly